### PR TITLE
fix: recover transcoder panics, allow AutoDJ edit, add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.vscode
+.idea
+node_modules
+server/frontend/node_modules
+server/frontend/dist
+dist
+tinyice
+*.log
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS frontend
+WORKDIR /src/server/frontend
+COPY server/frontend/package.json server/frontend/package-lock.json ./
+RUN npm ci
+COPY server/frontend/ ./
+RUN npm run build
+
+FROM golang:1.25-alpine AS builder
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=frontend /src/server/frontend/dist ./server/frontend/dist
+ARG VERSION=dev
+ARG COMMIT=unknown
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT}" \
+    -o /out/tinyice .
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates tzdata && \
+    adduser -D -u 10001 tinyice && \
+    mkdir -p /data && chown tinyice:tinyice /data
+COPY --from=builder /out/tinyice /usr/local/bin/tinyice
+USER tinyice
+WORKDIR /data
+EXPOSE 8080
+VOLUME ["/data"]
+ENTRYPOINT ["/usr/local/bin/tinyice"]
+CMD ["-port", "8080", "-config", "/data/config.json"]

--- a/relay/streamer.go
+++ b/relay/streamer.go
@@ -678,6 +678,23 @@ func (sm *StreamerManager) StopStreamer(mount string) {
 	}
 }
 
+// DeleteStreamer stops the streamer and removes it from the manager entirely.
+// Use this when the underlying AutoDJ config is being deleted (as opposed to
+// StopStreamer which keeps the instance around so the UI can restart it).
+func (sm *StreamerManager) DeleteStreamer(mount string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if s, ok := sm.instances[mount]; ok {
+		if s.MPDServer != nil {
+			logger.L.Debugf("AutoDJ %s: Stopping MPD server", s.Name)
+			s.MPDServer.Stop()
+		}
+		s.Stop()
+		delete(sm.instances, mount)
+	}
+}
+
 func (sm *StreamerManager) GetStreamers() []*Streamer {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()

--- a/relay/transcode.go
+++ b/relay/transcode.go
@@ -103,7 +103,7 @@ func (tm *TranscoderManager) runTranscoder(ctx context.Context, inst *Transcoder
 		case <-ctx.Done():
 			return
 		default:
-			tm.performTranscode(ctx, inst)
+			tm.safePerformTranscode(ctx, inst)
 			// Wait before retry if input stream wasn't found
 			select {
 			case <-ctx.Done():
@@ -112,6 +112,24 @@ func (tm *TranscoderManager) runTranscoder(ctx context.Context, inst *Transcoder
 			}
 		}
 	}
+}
+
+// safePerformTranscode wraps performTranscode with a panic recovery. Some
+// third-party decoders (e.g. go-mp3) can panic on malformed or non-MP3 input
+// instead of returning an error. Recovering here prevents a bad input stream
+// from taking down the whole server and lets the retry loop try again.
+func (tm *TranscoderManager) safePerformTranscode(ctx context.Context, inst *TranscoderInstance) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.L.Errorw("Transcoder: recovered from panic",
+				"name", inst.Config.Name,
+				"input", inst.Config.InputMount,
+				"output", inst.Config.OutputMount,
+				"panic", fmt.Sprintf("%v", r),
+			)
+		}
+	}()
+	tm.performTranscode(ctx, inst)
 }
 
 func (tm *TranscoderManager) performTranscode(ctx context.Context, inst *TranscoderInstance) {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -4,7 +4,12 @@ import (
 	"testing"
 
 	"github.com/DatanoiseTV/tinyice/config"
+	"github.com/DatanoiseTV/tinyice/logger"
 )
+
+func init() {
+	logger.Init("error", false, "")
+}
 
 func TestIPWhitelistAndBanning(t *testing.T) {
 	cfg := &config.Config{

--- a/server/handlers_api_v2.go
+++ b/server/handlers_api_v2.go
@@ -413,8 +413,12 @@ func (s *Server) apiCreateAutoDJ(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	if body.Name == "" || body.Mount == "" || body.MusicDir == "" {
-		jsonError(w, "Name, mount, and music_dir are required", http.StatusBadRequest)
+	if body.Name == "" || body.Mount == "" {
+		jsonError(w, "Name and mount are required", http.StatusBadRequest)
+		return
+	}
+	if body.MusicDir == "" && body.SongCommand == "" {
+		jsonError(w, "Either music_dir or song_command is required", http.StatusBadRequest)
 		return
 	}
 	if body.Mount[0] != '/' {
@@ -427,7 +431,10 @@ func (s *Server) apiCreateAutoDJ(w http.ResponseWriter, r *http.Request) {
 		body.Bitrate = 128
 	}
 
-	absMusicDir, _ := filepath.Abs(body.MusicDir)
+	absMusicDir := ""
+	if body.MusicDir != "" {
+		absMusicDir, _ = filepath.Abs(body.MusicDir)
+	}
 
 	adj := &config.AutoDJConfig{
 		Name:           body.Name,
@@ -459,7 +466,9 @@ func (s *Server) apiCreateAutoDJ(w http.ResponseWriter, r *http.Request) {
 			st.SetVisible(adj.Visible)
 		}
 	}
-	streamer.ScanMusicDir()
+	if adj.MusicDir != "" {
+		streamer.ScanMusicDir()
+	}
 	streamer.Play()
 	jsonResponse(w, map[string]string{"status": "created", "mount": adj.Mount})
 	s.Audit(r, "autodj_created", "autodj", body.Mount, body.Name)
@@ -487,7 +496,7 @@ func (s *Server) apiDeleteAutoDJ(w http.ResponseWriter, r *http.Request) {
 		if adj.Mount != mount {
 			newADJs = append(newADJs, adj)
 		} else {
-			s.StreamerM.StopStreamer(mount)
+			s.StreamerM.DeleteStreamer(mount)
 			found = true
 		}
 	}

--- a/server/handlers_player.go
+++ b/server/handlers_player.go
@@ -569,8 +569,13 @@ func (s *Server) handleAddAutoDJ(w http.ResponseWriter, r *http.Request) {
 	mpdPassword := r.FormValue("mpd_password")
 	visible := r.FormValue("visible") == "on"
 
-	if name == "" || mount == "" || musicDir == "" {
-		http.Error(w, "Name, mount, and music directory are required", http.StatusBadRequest)
+	songCommand := r.FormValue("song_command")
+	if name == "" || mount == "" {
+		http.Error(w, "Name and mount are required", http.StatusBadRequest)
+		return
+	}
+	if musicDir == "" && songCommand == "" {
+		http.Error(w, "Either music directory or song command is required", http.StatusBadRequest)
 		return
 	}
 
@@ -582,7 +587,10 @@ func (s *Server) handleAddAutoDJ(w http.ResponseWriter, r *http.Request) {
 		format = "mp3"
 	}
 
-	absMusicDir, _ := filepath.Abs(musicDir)
+	absMusicDir := ""
+	if musicDir != "" {
+		absMusicDir, _ = filepath.Abs(musicDir)
+	}
 
 	if mount[0] != '/' {
 		mount = "/" + mount
@@ -601,6 +609,7 @@ func (s *Server) handleAddAutoDJ(w http.ResponseWriter, r *http.Request) {
 		MPDPort:        mpdPort,
 		MPDPassword:    mpdPassword,
 		Visible:        visible,
+		SongCommand:    songCommand,
 	}
 
 	s.Config.AutoDJs = append(s.Config.AutoDJs, adj)
@@ -613,7 +622,9 @@ func (s *Server) handleAddAutoDJ(w http.ResponseWriter, r *http.Request) {
 				st.SetVisible(adj.Visible)
 			}
 		}
-		streamer.ScanMusicDir()
+		if adj.MusicDir != "" {
+			streamer.ScanMusicDir()
+		}
 		streamer.Play()
 	}
 
@@ -635,7 +646,7 @@ func (s *Server) handleDeleteAutoDJ(w http.ResponseWriter, r *http.Request) {
 		if adj.Mount != mount {
 			newADJs = append(newADJs, adj)
 		} else {
-			s.StreamerM.StopStreamer(mount)
+			s.StreamerM.DeleteStreamer(mount)
 		}
 	}
 	s.Config.AutoDJs = newADJs
@@ -755,8 +766,13 @@ func (s *Server) handleUpdateAutoDJ(w http.ResponseWriter, r *http.Request) {
 	mpdPassword := r.FormValue("mpd_password")
 	visible := r.FormValue("visible") == "on"
 
-	if name == "" || newMount == "" || musicDir == "" {
-		http.Error(w, "Name, mount, and music directory are required", http.StatusBadRequest)
+	songCommand := r.FormValue("song_command")
+	if name == "" || newMount == "" {
+		http.Error(w, "Name and mount are required", http.StatusBadRequest)
+		return
+	}
+	if musicDir == "" && songCommand == "" {
+		http.Error(w, "Either music directory or song command is required", http.StatusBadRequest)
 		return
 	}
 
@@ -767,7 +783,10 @@ func (s *Server) handleUpdateAutoDJ(w http.ResponseWriter, r *http.Request) {
 	bitrate := 128
 	fmt.Sscanf(bitrateStr, "%d", &bitrate)
 
-	absMusicDir, _ := filepath.Abs(musicDir)
+	absMusicDir := ""
+	if musicDir != "" {
+		absMusicDir, _ = filepath.Abs(musicDir)
+	}
 
 	for _, adj := range s.Config.AutoDJs {
 		if adj.Mount == oldMount {
@@ -782,8 +801,9 @@ func (s *Server) handleUpdateAutoDJ(w http.ResponseWriter, r *http.Request) {
 			adj.MPDPort = mpdPort
 			adj.MPDPassword = mpdPassword
 			adj.Visible = visible
+			adj.SongCommand = songCommand
 
-			s.StreamerM.StopStreamer(oldMount)
+			s.StreamerM.DeleteStreamer(oldMount)
 			streamer, err := s.StreamerM.StartStreamer(adj.Name, adj.Mount, absMusicDir, adj.Loop, adj.Format, adj.Bitrate, adj.InjectMetadata, adj.Playlist, adj.MPDEnabled, adj.MPDPort, adj.MPDPassword, adj.Visible, adj.LastPlaylist, adj.SongCommand, adj.SongCommandTimeout)
 			if err == nil {
 				if adj.Enabled {


### PR DESCRIPTION
## Summary
- Recover from panics inside the transcoder goroutine so malformed or non-MP3 inputs can no longer crash the server (#18).
- Add `StreamerManager.DeleteStreamer` and wire it into the AutoDJ delete/update handlers so editing an AutoDJ no longer fails with `streamer for mount ... already exists` (#17).
- Make the music directory optional when an external song command is configured, and preserve `song_command` on the HTML update handler (#17).
- Add a multi-stage Dockerfile (frontend -> Go builder -> Alpine runtime) and `.dockerignore` so the project can be run as a container (#15).

## Changes
- `relay/transcode.go`: `safePerformTranscode` wraps `performTranscode` in a `defer/recover`; the retry loop continues normally after a recovered panic.
- `relay/streamer.go`: new `DeleteStreamer(mount)` stops the streamer and removes it from `sm.instances`. `StopStreamer` remains as-is (keeps the instance so the UI can restart it).
- `server/handlers_api_v2.go`, `server/handlers_player.go`: delete and update paths call `DeleteStreamer`; `music_dir` is optional when `song_command` is set; `SongCommand` now persisted on HTML form updates.
- `Dockerfile`, `.dockerignore`: container build.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./relay/...` (passing; unrelated pre-existing failure in `server/TestIPWhitelistAndBanning` remains on `main`)
- [ ] Reproduce #18: point a transcoder at a non-MP3 input and verify the server no longer panics.
- [ ] Reproduce #17: create an AutoDJ, edit and save it, verify success.
- [ ] `docker build -t tinyice .` and start the resulting container.

Closes #17
Closes #18
Addresses #15